### PR TITLE
replace wget with curl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,9 +8,9 @@
 class typo3 (){
 
   if $::operatingsystem =~ /^(Debian|Ubuntu)$/ and versioncmp($::operatingsystemrelease, '12') < 0 {
-    $packages = [ 'wget', 'git-core' ]
+    $packages = [ 'curl', 'git-core' ]
   } else {
-    $packages = [ 'wget', 'git' ]
+    $packages = [ 'curl', 'git' ]
   }
 
   typo3::safe_package { $packages: ensure => 'installed' }

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -27,7 +27,7 @@ define typo3::install::source (
   $source_file = "${version}.tar.gz"
 
   exec { "Get ${name}":
-    command => "wget ${typo3::params::download_url}/${version} -O ${source_file}",
+    command => "curl -Lk ${typo3::params::download_url}/${version} >${source_file}",
     cwd     => $src_path,
     onlyif  => "test ! -d typo3_src-${version}",
   }


### PR DESCRIPTION
The newest TYPO3 version (`7.5.0` as of this writing) won't download using `wget` due to a Sourceforge-specific redirection / certificate issue. This pull request replaces the call to `wget` with a call to `curl`, which does not exhibit this erroneous behaviour.