### PR TITLE
Add a Path for exec

### DIFF
--- a/manifests/install/extension.pp
+++ b/manifests/install/extension.pp
@@ -52,20 +52,23 @@ define typo3::install::extension (
     cwd     => $path,
     onlyif  => "test ! -d ${path}/${key}",
     require => Package[$typo3::packages],
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
   exec {"git-checkout ${key}":
     command => "git checkout ${$tag}",
     cwd     => "${path}/${key}",
     notify  => Exec["chown ${key}"],
-    require => Exec["git-clone ${key}"]
+    require => Exec["git-clone ${key}"],
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
   exec {"chown ${key}":
     command     => "chown -R ${owner}:${group} ${path}/${key}",
     refreshonly => true,
     cwd         => $path,
-    require     => Exec["git-clone ${key}"]
+    require     => Exec["git-clone ${key}"],
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
 }

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -30,6 +30,7 @@ define typo3::install::source (
     command => "curl -Lk ${typo3::params::download_url}/${version} >${source_file}",
     cwd     => $src_path,
     onlyif  => "test ! -d typo3_src-${version}",
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
   exec { "Untar ${name}":
@@ -37,6 +38,7 @@ define typo3::install::source (
     cwd     => $src_path,
     require => Exec["Get ${name}"],
     creates => "${src_path}/typo3_src-${version}",
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
   exec { "Remove ${name}":
@@ -44,6 +46,7 @@ define typo3::install::source (
     cwd     => $src_path,
     require => Exec["Untar ${name}"],
     onlyif  => "test ! -f ${src_path}/${source_file}",
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
   }
 
 }

--- a/manifests/install/source/files.pp
+++ b/manifests/install/source/files.pp
@@ -51,6 +51,7 @@ define typo3::install::source::files (
       cwd     => $site_path,
       require => File[$target],
       unless  => 'test -L index.php',
+      path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
     }
 
     exec { "${site_path}: ln -s typo3_src/typo3 typo3":
@@ -58,6 +59,7 @@ define typo3::install::source::files (
       cwd     => $site_path,
       require => File[$target],
       unless  => 'test -d typo3',
+      path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
     }
 
     if versioncmp($version, '6.1.99') <= 0 {
@@ -66,6 +68,7 @@ define typo3::install::source::files (
         cwd     => $site_path,
         require => File[$target],
         unless  => 'test -d t3lib',
+        path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
       }
     }
 


### PR DESCRIPTION
Without this Bugfix, we get following error.
```
'test ! -d typo3_src-7.6.9' is not qualified and no path was specified. Please qualify the command or specify a path. at ....
```