### PR TITLE
Correct filepermissions

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -84,11 +84,11 @@ define typo3::project (
   include typo3
 
   if ( $site_user != $site_group ) {
-    $dir_permission     = 2770
-    $file_permission    = 660
+    $dir_permission     = '2770'
+    $file_permission    = '0660'
   } else {
-    $dir_permission     = 2755
-    $file_permission    = 644
+    $dir_permission     = '2755'
+    $file_permission    = '0644'
   }
 
   if ( $typo3_src_path == '' or $typo3_src_path == undef ) {


### PR DESCRIPTION
I get a warning with future parser.
```
Warning: Non-string values for the file mode property are deprecated. It must be a string, either a symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.
```

With this bugfix i can use this module with future parser.